### PR TITLE
Add support for justify

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ The variables at the start of the script can all be changed to modify the look a
 
 | Variable            	| Default                  	| Description                                                                    	| Useful Link(s)                                       	|
 |---------------------	|--------------------------	|--------------------------------------------------------------------------------	|------------------------------------------------------	|
-| font_name           	|   ``` '3x5'  ```         	| Changes the Figlet font which is rendered                                      	| [Figlet Font DB](http://www.figlet.org/fontdb.cgi)   	|
+| font_name           	|  ``` '3x5'  ```         	| Changes the Figlet font which is rendered                                      	| [Figlet Font DB](http://www.figlet.org/fontdb.cgi)   	|
 | padding             	|  ``` [0, 0, 0, 0] ```    	| Applies padding to the top/right/bottom/left of the text                       	|                                                      	|
+| width                 |  terminal width               | Defines the width for ```justify``` to work. By default is equal to terminal's width  |                                                       |
+| justify               |  ``` 'center' ```             | Justify the output ('auto', 'left', 'center', 'right')                                |                                                       |
 | custom_char_replace 	|  ``` {'#': '\u2588'} ``` 	| Used to replace the character(s) in the key with the character(s) in the value 	| [Unicode Character Table](https://unicode-table.com) 	|
 | time_format         	|  ``` '%H:%M:%S' ```      	| Set the format of the time to be displayed                                     	| [Time Formatting Parameters](http://strftime.org/)   	|
 

--- a/main.py
+++ b/main.py
@@ -9,6 +9,8 @@ except ImportError:
 
 # VARIABLES
 padding             = [1, 0, 0, 3]
+width               = os.get_terminal_size().columns
+justify             = 'center'
 font_name           = '3x5'
 custom_char_replace = {'#': '\u2588'}
 time_format         = '%H:%M:%S'
@@ -22,7 +24,7 @@ while True:
     time_string = datetime.datetime.now().strftime(time_format)
 
     # Turn the string into a figlet ASCII art string
-    figlet_string = figlet_format(time_string, font=font_name)
+    figlet_string = figlet_format(time_string, font=font_name, width=width, justify=justify)
 
     # Replace any characters
     for char in custom_char_replace:


### PR DESCRIPTION
Added `width` and `justify` variables to control corresponding clock behaviour. Width is automatically acquired from terminal's width and the clock is centered by default.